### PR TITLE
fix DELETE_X_BLOCKS count message

### DIFF
--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -548,13 +548,32 @@ const registerDelete = function() {
     displayText: function(scope) {
       let descendantCount = 0;
       const countDescendants = function(block) {
-        if (block) {
-          descendantCount += block.getDescendants(false).length;
-          const nextBlock = block.getNextBlock();
-          if (nextBlock) {
-            descendantCount -= nextBlock.getDescendants(false).length;
+        if (!block) return;
+
+        const countBlockAndDescendants = function(currentBlock) {
+          let count = 1; // initial block
+
+          for (const input of currentBlock.inputList) {
+            if (input.connection && input.connection.targetBlock()) {
+              const connectedBlock = input.connection.targetBlock();
+              if (input.type === Blockly.inputTypes.STATEMENT) {
+                // For statement inputs, count the entire chain of next blocks
+                let nextInChain = connectedBlock;
+                while (nextInChain) {
+                  count += countBlockAndDescendants(nextInChain);
+                  nextInChain = nextInChain.getNextBlock();
+                }
+              } else {
+                // For value inputs, just count the connected block tree
+                count += countBlockAndDescendants(connectedBlock);
+              }
+            }
           }
-        }
+
+          return count;
+        };
+
+        descendantCount += countBlockAndDescendants(block);
       };
 
       countDescendants(scope.block);

--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -551,21 +551,18 @@ const registerDelete = function() {
         if (!block) return;
 
         const countBlockAndDescendants = function(currentBlock) {
-          let count = 1; // initial block
-
+          let count = 1; // Initial block
           for (const input of currentBlock.inputList) {
             if (input.connection && input.connection.targetBlock()) {
               const connectedBlock = input.connection.targetBlock();
+              count += countBlockAndDescendants(connectedBlock);
+              // For statement inputs, also follow the next chain
               if (input.type === Blockly.inputTypes.STATEMENT) {
-                // For statement inputs, count the entire chain of next blocks
-                let nextInChain = connectedBlock;
-                while (nextInChain) {
-                  count += countBlockAndDescendants(nextInChain);
-                  nextInChain = nextInChain.getNextBlock();
+                let nextInStatement = connectedBlock.getNextBlock();
+                while (nextInStatement) {
+                  count += countBlockAndDescendants(nextInStatement);
+                  nextInStatement = nextInStatement.getNextBlock();
                 }
-              } else {
-                // For value inputs, just count the connected block tree
-                count += countBlockAndDescendants(connectedBlock);
               }
             }
           }
@@ -576,7 +573,21 @@ const registerDelete = function() {
         descendantCount += countBlockAndDescendants(block);
       };
 
-      countDescendants(scope.block);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
+      const isInMultiselection = blockSelection &&
+        blockSelection.has(scope.block.id);
+
+      if (!isInMultiselection) {
+        countDescendants(scope.block);
+      } else {
+        blockSelection.forEach(function(id) {
+          const block = workspace.getBlockById(id);
+          if (block && !hasSelectedParent(block)) {
+            countDescendants(block);
+          }
+        });
+      }
 
       return (descendantCount <= 1) ?
         Blockly.Msg['DELETE_BLOCK'] :

--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -576,9 +576,9 @@ const registerDelete = function() {
       const workspace = scope.block.workspace;
       const blockSelection = blockSelectionWeakMap.get(workspace);
       const isInMultiselection = blockSelection &&
-        blockSelection.has(scope.block.id);
+          blockSelection.has(scope.block.id);
 
-      if (!isInMultiselection) {
+      if (!blockSelection || blockSelection.size === 0 || !isInMultiselection) {
         countDescendants(scope.block);
       } else {
         blockSelection.forEach(function(id) {

--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -547,20 +547,18 @@ const registerDelete = function() {
   const deleteOption = {
     displayText: function(scope) {
       let descendantCount = 0;
-      const workspace = scope.block.workspace;
-      const blockSelection = blockSelectionWeakMap.get(workspace);
-      blockSelection.forEach(function(id) {
-        const block = workspace.getBlockById(id);
-        if (block && !hasSelectedParent(block)) {
-          // Count the number of blocks that are nested in this block.
+      const countDescendants = function(block) {
+        if (block) {
           descendantCount += block.getDescendants(false).length;
           const nextBlock = block.getNextBlock();
           if (nextBlock) {
-            // Blocks in the current stack would survive this block's deletion.
             descendantCount -= nextBlock.getDescendants(false).length;
           }
         }
-      });
+      };
+
+      countDescendants(scope.block);
+
       return (descendantCount <= 1) ?
         Blockly.Msg['DELETE_BLOCK'] :
         Blockly.Msg['DELETE_X_BLOCKS'].replace('%1', String(descendantCount));


### PR DESCRIPTION
This is a different fix from the same issue in the main branch of the main repo, as the functions have diverged: https://github.com/mit-cml/workspace-multiselect/pull/107

It fixes the issue with erratic counts for the delete blocks message reported https://github.com/mit-cml/appinventor-sources/issues/3390

The issue in this case was that the countDescendants function was using `!hasSelectedParent(block)` to skip counting blocks that have selected parents. The function now always count the descendants of the right-clicked block, and removes the issues that you'd have to right click twice and, at times, you'd get the value for the previous selection.

NOTE: I have not tested this within App Inventor but it works in the test file here.

